### PR TITLE
Fix potential memory leak in long-lived `Shaped::Array` instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,8 @@
 - Add `Array` refinement
 - Add `Shaped::MatchFailureReason` and `Shaped::Array#match_failure_reason`
 
+### Fixed
+- Fix potential memory leak in long-lived `Shaped::Array` instances
+
 ## 0.1.0 - 2020-06-16
 - Initial release of Shaped! Validate the shape of Ruby hashes and/or arrays.

--- a/lib/shaped/array.rb
+++ b/lib/shaped/array.rb
@@ -19,6 +19,12 @@ class Shaped::Array
   end
 
   def matched_by?(array)
+    # avoid a memory leak from indefinitely adding to the @match_failure_reasons hash; we just want
+    # to use it to memoize recently checked arrays (we'll somewhat arbitrarily go with 10 of them)
+    if @match_failure_reasons.size > 10
+      @match_failure_reasons = {}
+    end
+
     if array.empty?
       Shaped.lax_mode?
     elsif @match_failure_reasons.key?(array)


### PR DESCRIPTION
I _think_ this would have been a possible memory leak?, and I think that this fix will avoid such a memory leak? I'm not 100% sure about either of those hypotheses, though.