### PR TITLE
Rename Shaped::Shape#descriptor methods to #to_s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Changed
+- Rename `Shaped::Array#descriptor` and `Shaped::Hash#descriptor` methods to `#to_s`
+
 ## 0.2.0 - 2020-06-16
 ### Added
 - Add `Shaped::Array` method and class

--- a/lib/shaped/array.rb
+++ b/lib/shaped/array.rb
@@ -22,7 +22,7 @@ class Shaped::Array < Shaped::Shape
     @match_failure_reasons = {}
   end
 
-  def descriptor
+  def to_s
     "Array shaped like [#{@shape_klass}]"
   end
 

--- a/lib/shaped/expected_class_descriptions.rb
+++ b/lib/shaped/expected_class_descriptions.rb
@@ -5,7 +5,7 @@ module Shaped::ExpectedClassDescriptions
 
   def expected_class_descriptor(expected_klass)
     if expected_klass.is_a?(Shaped::Shape)
-      expected_klass.descriptor
+      expected_klass.to_s
     else
       expected_klass.name
     end

--- a/lib/shaped/hash.rb
+++ b/lib/shaped/hash.rb
@@ -15,7 +15,7 @@ class Shaped::Hash < Shaped::Shape
     @match_failure_reasons = {}
   end
 
-  def descriptor
+  def to_s
     printable_shape_description =
       @shape_description.map do |key, value|
         "#{key.inspect} => #{expected_class_descriptor(value)}"


### PR DESCRIPTION
This makes it easier to integrate into / be used by other gems, since it makes instances of `Shaped::Array` and `Shaped::Hash` more "class like" since now both classes and those `Shaped::Shape` classes can respond to that same `#to_s` method.