### PR TITLE
Fix typo in test (`@number.event?` => `@number.even?`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Specs
+- Fix typo in test (`@number.event?` => `@number.even?`)
+
 ## v0.5.3 (2020-06-19)
 ### Docs
 - Fill out the "Usage" section of README.md

--- a/spec/shapes/callable_spec.rb
+++ b/spec/shapes/callable_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Shaped::Shapes::Callable do
             private
 
             def number_is_even?
-              @number.event?
+              @number.even?
             end
           end,
         )


### PR DESCRIPTION
This typo wasn't actually causing problems because the method within which the typo existed was never actually called; it was just for illustrative purposes. Still, we should fix the typo.