### PR TITLE
Remove explicit `git push` from release instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Docs
+- Remove explicit `git push` from release instructions
+
 ## v0.6.3 (2020-06-21)
 ### Docs
 - Add badges for Dependabot status and RubyGems version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    shaped (0.6.3)
+    shaped (0.6.4.alpha)
       activemodel (~> 6.0)
       activesupport (~> 6.0)
 

--- a/README.md
+++ b/README.md
@@ -358,8 +358,7 @@ To release a new version:
 3. update the version number in `version.rb`
 4. `bundle install` (which will update `Gemfile.lock`)
 5. commit the changes with a message like `Prepare to release v0.1.1`
-6. push the changes to `origin/master` (GitHub) via `git push`
-7. run `bin/release` (which will create a git tag for the version, push git commits and
+6. run `bin/release` (which will create a git tag for the version, push git commits and
    tags to GitHub, and push the gem to RubyGems)
 
 # License

--- a/lib/shaped/version.rb
+++ b/lib/shaped/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Shaped
-  VERSION = '0.6.3'
+  VERSION = '0.6.4.alpha'
 end


### PR DESCRIPTION
`git push` will be done automatically by the `bundle exec rake release` command in `bin/release`.