### PR TITLE
Make it possible to specify optional keys in a Hash shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+### Fixed
+- Make it possible to specify optional keys in a Hash shape (using an `Or` shape as the value)
+
 ### Docs
 - Remove explicit `git push` from release instructions
 

--- a/lib/shaped.rb
+++ b/lib/shaped.rb
@@ -27,6 +27,7 @@ module Shaped
         end
 
       case shape_description
+      when Shaped::Shape then shape_description
       when Hash then Shaped::Shapes::Hash.new(shape_description)
       when Array then Shaped::Shapes::Array.new(shape_description)
       when Class then Shaped::Shapes::Class.new(shape_description, validation_options)

--- a/lib/shaped/shapes/hash.rb
+++ b/lib/shaped/shapes/hash.rb
@@ -12,9 +12,6 @@ class Shaped::Shapes::Hash < Shaped::Shape
   def matched_by?(hash)
     return false if !hash.is_a?(Hash)
 
-    missing_keys = expected_keys - hash.keys
-    return false if missing_keys.any?
-
     @hash_description.all? do |key, expected_value_shape|
       expected_value_shape.matched_by?(hash[key])
     end
@@ -27,11 +24,5 @@ class Shaped::Shapes::Hash < Shaped::Shape
       end.join(', ')
 
     "{ #{printable_shape_description} }"
-  end
-
-  private
-
-  def expected_keys
-    @hash_description.keys
   end
 end

--- a/spec/shaped_spec.rb
+++ b/spec/shaped_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe(Shaped) do
     context 'when called with a single argument (a shape description)' do
       subject(:shape) { Shaped::Shape(shape_description) }
 
+      context 'when called with a Shaped::Shape' do
+        let(:shape_description) { Shaped::Shape(Numeric, nil) }
+
+        it 'returns the shape_description itself' do
+          expect(shape).to eq(shape_description)
+        end
+      end
+
       context 'when called with a Hash' do
         let(:shape_description) { { email: String } }
 

--- a/spec/shapes/hash_spec.rb
+++ b/spec/shapes/hash_spec.rb
@@ -48,8 +48,54 @@ RSpec.describe Shaped::Shapes::Hash do
         end
       end
 
-      context 'when the test hash does not match the specified shape' do
+      context 'when the test hash has an Integer email value' do
         let(:test_hash) { { email: 2_048 } }
+
+        it 'returns false' do
+          expect(matched_by?).to eq(false)
+        end
+      end
+
+      context 'when the test hash has an extra key (`:name`)' do
+        let(:test_hash) { { email: 'jim@gmail.com', name: 'Jimbo' } }
+
+        it 'returns true' do
+          expect(matched_by?).to eq(true)
+        end
+      end
+    end
+
+    context 'when the shape description is `{ email: Shaped::Shape(String, NilClass) }`' do
+      subject(:hash_shape_description) { { email: Shaped::Shape(String, nil) } }
+
+      context "when the test hash is { email: 'jim@gmail.com' }" do
+        let(:test_hash) { { email: 'jim@gmail.com' } }
+
+        it 'returns true' do
+          expect(matched_by?).to eq(true)
+        end
+      end
+
+      context 'when the test hash is { email: nil }' do
+        let(:test_hash) { { email: nil } }
+
+        it 'returns true' do
+          expect(matched_by?).to eq(true)
+        end
+      end
+
+      context 'when the test hash is an empty hash' do
+        # although the :email key is not given explicitly, the
+        # value is effectively `nil`, which is an allowed value.
+        let(:test_hash) { {} }
+
+        it 'returns true' do
+          expect(matched_by?).to eq(true)
+        end
+      end
+
+      context 'when the test hash is { email: 951 }' do
+        let(:test_hash) { { email: 951 } }
 
         it 'returns false' do
           expect(matched_by?).to eq(false)
@@ -63,6 +109,14 @@ RSpec.describe Shaped::Shapes::Hash do
 
     it 'returns a readably formatted description of the expected hash shape' do
       expect(to_s).to eq('{ :email => String }')
+    end
+
+    context 'when an expected value is a specific string' do
+      let(:hash_shape_description) { { secret_key: 'ABC123' } }
+
+      it 'renders the string within quotes' do
+        expect(to_s).to eq('{ :secret_key => "ABC123" }')
+      end
     end
   end
 end


### PR DESCRIPTION
Optional hash keys can now effectively be specified by using an `Or` shape as a value in the Hash's shape description (using `nil` or `NilClass` as one of the allowed values/classes for the `Or` shape).