### PR TITLE
Add an All shape (multiple sub-shapes, all of which must be matched)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### BREAKING CHANGES
 - Rename the `Or` shape to `Any`
 
+### Added
+- Add an `All` shape (w/ multiple sub-shapes, all of which must be matched)
+
 ## v0.6.4 (2020-06-22)
 ### Fixed
 - Make it possible to specify optional keys in a Hash shape (using an `Or` shape as the value)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ Validate the "shape" of Ruby objects!
       * [Shaped::Shapes::Callable](#shapedshapescallable)
       * [Shaped::Shapes::Equality](#shapedshapesequality)
       * [Shaped::Shapes::Any](#shapedshapesany)
+      * [Shaped::Shapes::All](#shapedshapesall)
       * [#to_s](#to_s)
    * [Development](#development)
    * [For maintainers](#for-maintainers)
    * [License](#license)
 
-<!-- Added by: david, at: Wed Jun 24 13:02:34 PDT 2020 -->
+<!-- Added by: david, at: Wed Jun 24 13:23:10 PDT 2020 -->
 
 <!--te-->
 
@@ -299,7 +300,7 @@ shape.matched_by?([0.333, 55])
 # => false
 ```
 
-You can build an `Or` shape by invoking the `Shaped::Shape` constructor with more than one argument.
+You can build an `Any` shape by invoking the `Shaped::Shape` constructor with more than one argument.
 Below is a (rather artificial) example illustrating this. To match this `shape`, an object must be
 either greater than zero OR an Integer (or both).
 
@@ -313,6 +314,23 @@ shape.matched_by?(11.5) # it's greater than 0
 # => true
 
 shape.matched_by?(-11.5) # it's neither greater than 0 nor an Integer
+# => false
+```
+
+## Shaped::Shapes::All
+
+This shape can be used to combine multiple checks, all of which must be true for a test object in
+order for `#matched_by?` to be true:
+
+```rb
+shape = Shaped::Shapes::All.new(Numeric, ->(number) { number.even? })
+shape.to_s
+# => "Numeric AND Proc test defined at (eval):10"
+
+shape.matched_by?(22) # 22 is both a Numeric and `#even?`
+# => true
+
+shape.matched_by?(33) # 33 is a Numeric but it's not `#even?`
 # => false
 ```
 

--- a/lib/shaped/shapes/all.rb
+++ b/lib/shaped/shapes/all.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Shaped::Shapes::All < Shaped::Shape
+  def initialize(*shape_descriptions)
+    validation_options = shape_descriptions.extract_options!
+    if shape_descriptions.size <= 1
+      raise(Shaped::InvalidShapeDescription, <<~ERROR.squish)
+        A #{self.class} description must be a list of two or more shape descriptions.
+      ERROR
+    end
+
+    @shapes =
+      shape_descriptions.map do |description|
+        Shaped::Shape(description, validation_options)
+      end
+  end
+
+  def matched_by?(object)
+    @shapes.all? { |shape| shape.matched_by?(object) }
+  end
+
+  def to_s
+    @shapes.map(&:to_s).join(' AND ')
+  end
+end

--- a/spec/shapes/all_spec.rb
+++ b/spec/shapes/all_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe Shaped::Shapes::All do
+  subject(:all_shape) { Shaped::Shapes::All.new(*all_shape_descriptions) }
+
+  let(:all_shape_descriptions) { [Numeric, ->(number) { number.even? }] }
+  let(:test_object) { 88 }
+
+  describe '#initialize' do
+    context 'when initialized with a list of multiple classes' do
+      before { expect(all_shape_descriptions.size).to be >= 2 }
+
+      it 'does not raise an error' do
+        expect { all_shape }.not_to raise_error
+      end
+    end
+
+    context 'when initialized with a single argument' do
+      let(:all_shape_descriptions) { [Numeric] }
+
+      it 'raises an error' do
+        expect { all_shape }.to raise_error(Shaped::InvalidShapeDescription, <<~ERROR.squish)
+          A Shaped::Shapes::All description must be a list of two or more shape descriptions.
+        ERROR
+      end
+    end
+  end
+
+  describe '#matched_by?' do
+    subject(:matched_by?) { all_shape.matched_by?(test_object) }
+
+    context 'when the test object satisfies all of the sub-shape descriptions' do
+      before do
+        expect(test_object).to be_a(all_shape_descriptions.first)
+        expect(all_shape_descriptions.second.call(test_object)).to eq(true)
+      end
+
+      it 'returns true' do
+        expect(matched_by?).to eq(true)
+      end
+    end
+
+    context 'when the test object does not satisfy all of the shape descriptions' do
+      let(:test_object) { 33 }
+
+      before do
+        expect(test_object).to be_a(all_shape_descriptions.first) # matched
+        expect(all_shape_descriptions.second.call(test_object)).to eq(false) # not matched
+      end
+
+      it 'returns false' do
+        expect(matched_by?).to eq(false)
+      end
+    end
+  end
+
+  describe '#to_s' do
+    subject(:to_s) { all_shape.to_s }
+
+    it 'returns a readably formatted description of the list of allowed shapes' do
+      expect(to_s).to match(/Numeric AND Proc test defined at .*all_spec\.rb:\d+/)
+    end
+  end
+end

--- a/spec/shapes/any_spec.rb
+++ b/spec/shapes/any_spec.rb
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 
 RSpec.describe Shaped::Shapes::Any do
-  subject(:or_shape) { Shaped::Shapes::Any.new(*or_shape_descriptions) }
+  subject(:any_shape) { Shaped::Shapes::Any.new(*any_shape_descriptions) }
 
-  let(:or_shape_descriptions) { [Numeric, String] }
+  let(:any_shape_descriptions) { [Numeric, String] }
   let(:test_object) { 'David Runger' }
 
   describe '#initialize' do
     context 'when initialized with a list of multiple classes' do
-      let(:or_shape_descriptions) { [Numeric, String] }
+      let(:any_shape_descriptions) { [Numeric, String] }
 
       it 'does not raise an error' do
-        expect { or_shape }.not_to raise_error
+        expect { any_shape }.not_to raise_error
       end
     end
 
     context 'when initialized with a list of multiple array descriptions' do
-      let(:or_shape_descriptions) { [[Numeric], [String]] }
+      let(:any_shape_descriptions) { [[Numeric], [String]] }
 
       it 'does not raise an error' do
-        expect { or_shape }.not_to raise_error
+        expect { any_shape }.not_to raise_error
       end
 
       describe '#matched_by?' do
-        subject(:matched_by?) { or_shape.matched_by?(test_object) }
+        subject(:matched_by?) { any_shape.matched_by?(test_object) }
 
         context 'when the test object is an array of only Numerics' do
           let(:test_object) { [1, 2.0, Rational(3, 4)] }
@@ -52,10 +52,10 @@ RSpec.describe Shaped::Shapes::Any do
     end
 
     context 'when initialized with a single argument' do
-      let(:or_shape_descriptions) { [Numeric] }
+      let(:any_shape_descriptions) { [Numeric] }
 
       it 'raises an error' do
-        expect { or_shape }.to raise_error(Shaped::InvalidShapeDescription, <<~ERROR.squish)
+        expect { any_shape }.to raise_error(Shaped::InvalidShapeDescription, <<~ERROR.squish)
           A Shaped::Shapes::Any description must be a list of two or more shape descriptions.
         ERROR
       end
@@ -63,10 +63,10 @@ RSpec.describe Shaped::Shapes::Any do
   end
 
   describe '#matched_by?' do
-    subject(:matched_by?) { or_shape.matched_by?(test_object) }
+    subject(:matched_by?) { any_shape.matched_by?(test_object) }
 
     context 'when the test object satisfies one of the shape descriptions' do
-      before { expect(test_object).to be_a(or_shape_descriptions.second) }
+      before { expect(test_object).to be_a(any_shape_descriptions.second) }
 
       it 'returns true' do
         expect(matched_by?).to eq(true)
@@ -75,7 +75,7 @@ RSpec.describe Shaped::Shapes::Any do
 
     context 'when the test object does not satisfy any of the shape descriptions' do
       before do
-        or_shape_descriptions.each do |klass|
+        any_shape_descriptions.each do |klass|
           expect(test_object).not_to be_a(klass)
         end
       end
@@ -89,7 +89,7 @@ RSpec.describe Shaped::Shapes::Any do
   end
 
   describe '#to_s' do
-    subject(:to_s) { or_shape.to_s }
+    subject(:to_s) { any_shape.to_s }
 
     it 'returns a readably formatted description of the list of allowed shapes' do
       expect(to_s).to eq('Numeric OR String')


### PR DESCRIPTION
(plus some unrelated changes cleaning up the `Or` => `Any` rename)