### PR TITLE
Bump codecov/codecov-action from v3 to v4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Ensure no git diff
       run: git diff --exit-code && git diff-index --quiet --cached HEAD
     - name: Upload Code Coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         directory: tmp/simple_cov
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This fixes a deprecation warning about "Node.js 16 actions are deprecated" and I think will also make coverage uploads more reliable.