### PR TITLE
[gemspec] Remove upper bounds on versions for all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Remove upper bounds on versions for all dependencies
 
 ## v0.13.0 (2024-06-28)
 - Enforce only major and minor parts of required Ruby version (loosening the required Ruby version from 3.3.3 to 3.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     shaped (0.13.1.alpha)
-      activemodel (>= 6, < 8)
-      activesupport (>= 6, < 8)
+      activemodel (>= 6)
+      activesupport (>= 6)
 
 GEM
   remote: https://rubygems.org/

--- a/shaped.gemspec
+++ b/shaped.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
     end
   spec.require_paths = ['lib']
 
-  spec.add_dependency('activemodel', '>= 6', '< 8')
-  spec.add_dependency('activesupport', '>= 6', '< 8')
+  spec.add_dependency('activemodel', '>= 6')
+  spec.add_dependency('activesupport', '>= 6')
 end


### PR DESCRIPTION
Let's optimistically assume that all future versions of our gem dependencies will be compatible. We can add restrictions if that turns out not to be the case. The upside of this change is that we don't have to make changes in this gem when new versions of these dependencies are released.