### PR TITLE
Require 'test' group gems in spec_helper.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ SimpleCov.start do
 end
 
 require 'bundler/setup'
-Bundler.require
+Bundler.require(:default, 'test')
 
 require 'shaped'
 


### PR DESCRIPTION
This will make test gems automatically available, which will follow the principle of least surprise.